### PR TITLE
feat: per-pipeline dimming for linked CodePipeline bars

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -103,6 +103,7 @@ mod tests {
             stages: vec![],
             gone: false,
             summary_status: BuildStatus::Running,
+            pending_link: false,
         });
         assert!(app.has_any_running());
     }
@@ -117,6 +118,7 @@ mod tests {
             stages: vec![stage],
             gone: false,
             summary_status: BuildStatus::Succeeded,
+            pending_link: false,
         });
         assert!(app.has_any_running());
     }
@@ -170,6 +172,7 @@ mod tests {
             stages: vec![],
             gone: false,
             summary_status: BuildStatus::Succeeded,
+            pending_link: false,
         });
         app.workflow_groups.push(WorkflowGroup {
             name: "CI".into(),
@@ -190,12 +193,14 @@ mod tests {
             stages: vec![],
             gone: false,
             summary_status: BuildStatus::Succeeded,
+            pending_link: false,
         });
         app.pipeline_groups.push(PipelineGroup {
             name: "p2".into(),
             stages: vec![],
             gone: false,
             summary_status: BuildStatus::Failed,
+            pending_link: false,
         });
         assert!(!app.has_any_running());
         // Now add one with a running stage
@@ -206,6 +211,7 @@ mod tests {
             stages: vec![stage],
             gone: false,
             summary_status: BuildStatus::Idle,
+            pending_link: false,
         });
         assert!(app.has_any_running());
     }

--- a/src/linkage.rs
+++ b/src/linkage.rs
@@ -222,6 +222,9 @@ pub fn apply_links(
         running_links.into_iter().chain(correlated_links).collect();
 
     if all_links.is_empty() {
+        // Still need to set pending_link for linked pipelines
+        let mut a = app.lock().expect("app mutex poisoned");
+        set_pending_links(&mut a, link_map);
         return;
     }
 
@@ -253,6 +256,23 @@ pub fn apply_links(
                     }
                 }
             }
+        }
+    }
+
+    set_pending_links(&mut a, link_map);
+}
+
+/// Set `pending_link` on pipeline groups based on linked workflow state.
+fn set_pending_links(app: &mut App, link_map: &LinkMap) {
+    for pg in &mut app.pipeline_groups {
+        if let Some(wf_name) = link_map.workflow_for_pipeline(&pg.name) {
+            let linked_wf_running = app
+                .workflow_groups
+                .iter()
+                .any(|wg| wg.name == wf_name && wg.summary_status == BuildStatus::Running);
+            pg.pending_link = linked_wf_running && pg.summary_status != BuildStatus::Running;
+        } else {
+            pg.pending_link = false;
         }
     }
 }
@@ -425,6 +445,7 @@ mod tests {
             stages: vec![],
             gone: false,
             summary_status: BuildStatus::Running,
+            pending_link: false,
         });
 
         let mut link_map = LinkMap::new();
@@ -466,6 +487,7 @@ mod tests {
             stages: vec![],
             gone: false,
             summary_status: BuildStatus::Succeeded, // Not Running
+            pending_link: false,
         });
 
         let app = Arc::new(Mutex::new(app));
@@ -508,6 +530,7 @@ mod tests {
             stages: vec![],
             gone: false,
             summary_status: BuildStatus::Running,
+            pending_link: false,
         });
 
         let app = Arc::new(Mutex::new(app));
@@ -544,6 +567,7 @@ mod tests {
                 stages: vec![],
                 gone: false,
                 summary_status: BuildStatus::Running,
+                pending_link: false,
             });
         }
 
@@ -585,6 +609,7 @@ mod tests {
             stages: vec![],
             gone: false,
             summary_status: BuildStatus::Running,
+            pending_link: false,
         });
 
         let app = Arc::new(Mutex::new(app));
@@ -617,6 +642,7 @@ mod tests {
             stages: vec![],
             gone: false,
             summary_status: BuildStatus::Running,
+            pending_link: false,
         });
 
         let app = Arc::new(Mutex::new(app));
@@ -699,6 +725,7 @@ mod tests {
             stages: vec![],
             gone: false,
             summary_status: BuildStatus::Running,
+            pending_link: false,
         });
         let app = Arc::new(Mutex::new(app));
         let mut link_map = LinkMap::new();
@@ -734,6 +761,7 @@ mod tests {
             stages: vec![],
             gone: false,
             summary_status: BuildStatus::Running,
+            pending_link: false,
         });
         let app = Arc::new(Mutex::new(app));
         let mut link_map = LinkMap::new();
@@ -783,5 +811,135 @@ mod tests {
     #[test]
     fn s3_keys_slash_only() {
         assert!(!s3_keys_match("/", "my-app"));
+    }
+
+    // --- pending_link tests ---
+
+    #[test]
+    fn pending_link_set_when_gh_running_cp_idle() {
+        let mut app = App::new();
+        app.workflow_groups.push(WorkflowGroup {
+            name: "CI".into(),
+            jobs: vec![],
+            gone: false,
+            summary_status: BuildStatus::Running,
+            run_id: Some(100),
+            category: WorkflowCategory::default(),
+        });
+        app.pipeline_groups.push(PipelineGroup {
+            name: "deploy-pipe".into(),
+            stages: vec![],
+            gone: false,
+            summary_status: BuildStatus::Idle,
+            pending_link: false,
+        });
+
+        let app = Arc::new(Mutex::new(app));
+        let mut link_map = LinkMap::new();
+        link_map.add_discovered("deploy-pipe".into(), "CI".into(), "b".into(), "k".into());
+
+        apply_links(&app, &mut link_map, &mut HashMap::new());
+
+        let a = app.lock().unwrap();
+        assert!(
+            a.pipeline_groups[0].pending_link,
+            "linked CP should be pending when GH is Running and CP is Idle"
+        );
+    }
+
+    #[test]
+    fn pending_link_cleared_when_cp_running() {
+        let mut app = App::new();
+        let mut job = Bar::new("build".into());
+        job.set_status(BuildStatus::Running);
+        app.workflow_groups.push(WorkflowGroup {
+            name: "CI".into(),
+            jobs: vec![job],
+            gone: false,
+            summary_status: BuildStatus::Running,
+            run_id: Some(100),
+            category: WorkflowCategory::default(),
+        });
+        app.pipeline_groups.push(PipelineGroup {
+            name: "deploy-pipe".into(),
+            stages: vec![],
+            gone: false,
+            summary_status: BuildStatus::Running,
+            pending_link: false,
+        });
+
+        let app = Arc::new(Mutex::new(app));
+        let mut link_map = LinkMap::new();
+        link_map.add_discovered("deploy-pipe".into(), "CI".into(), "b".into(), "k".into());
+
+        apply_links(&app, &mut link_map, &mut HashMap::new());
+
+        let a = app.lock().unwrap();
+        assert!(
+            !a.pipeline_groups[0].pending_link,
+            "pending_link should be false when CP is Running"
+        );
+    }
+
+    #[test]
+    fn pending_link_false_for_unlinked() {
+        let mut app = App::new();
+        app.workflow_groups.push(WorkflowGroup {
+            name: "CI".into(),
+            jobs: vec![],
+            gone: false,
+            summary_status: BuildStatus::Running,
+            run_id: Some(100),
+            category: WorkflowCategory::default(),
+        });
+        app.pipeline_groups.push(PipelineGroup {
+            name: "unlinked-pipe".into(),
+            stages: vec![],
+            gone: false,
+            summary_status: BuildStatus::Idle,
+            pending_link: false,
+        });
+
+        let app = Arc::new(Mutex::new(app));
+        let mut link_map = LinkMap::new(); // no links
+        apply_links(&app, &mut link_map, &mut HashMap::new());
+
+        let a = app.lock().unwrap();
+        assert!(
+            !a.pipeline_groups[0].pending_link,
+            "unlinked pipeline should not have pending_link"
+        );
+    }
+
+    #[test]
+    fn pending_link_false_when_gh_succeeded() {
+        let mut app = App::new();
+        app.workflow_groups.push(WorkflowGroup {
+            name: "CI".into(),
+            jobs: vec![],
+            gone: false,
+            summary_status: BuildStatus::Succeeded,
+            run_id: Some(100),
+            category: WorkflowCategory::default(),
+        });
+        app.pipeline_groups.push(PipelineGroup {
+            name: "deploy-pipe".into(),
+            stages: vec![],
+            gone: false,
+            summary_status: BuildStatus::Idle,
+            pending_link: false,
+        });
+
+        let app = Arc::new(Mutex::new(app));
+        let mut link_map = LinkMap::new();
+        link_map.add_discovered("deploy-pipe".into(), "CI".into(), "b".into(), "k".into());
+
+        apply_links(&app, &mut link_map, &mut HashMap::new());
+
+        let a = app.lock().unwrap();
+        assert!(
+            !a.pipeline_groups[0].pending_link,
+            "pending_link should be false when GH workflow Succeeded"
+        );
     }
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -118,6 +118,8 @@ pub struct PipelineGroup {
     pub stages: Vec<Bar>,
     pub gone: bool,
     pub summary_status: BuildStatus,
+    /// True when linked GH workflow is still running but this pipeline hasn't started yet.
+    pub pending_link: bool,
 }
 
 #[cfg(test)]
@@ -467,6 +469,7 @@ mod tests {
             stages: vec![],
             gone: false,
             summary_status: BuildStatus::Idle,
+            pending_link: false,
         };
         assert_eq!(group.name, "deploy-pipe");
         assert!(group.stages.is_empty());
@@ -483,6 +486,7 @@ mod tests {
             ],
             gone: false,
             summary_status: BuildStatus::Running,
+            pending_link: false,
         };
         assert_eq!(group.stages.len(), 2);
         assert_eq!(group.stages[0].name, "Source");
@@ -496,6 +500,7 @@ mod tests {
             stages: vec![],
             gone: false,
             summary_status: BuildStatus::Idle,
+            pending_link: false,
         };
         group.gone = true;
         assert!(group.gone);

--- a/src/poller/mod.rs
+++ b/src/poller/mod.rs
@@ -297,6 +297,7 @@ fn update_pipeline_groups(app: &mut App, states: Vec<PipelineState>) {
                 stages: Vec::new(),
                 gone: false,
                 summary_status: state.status,
+                pending_link: false,
             };
             reconcile_bars(&mut group.stages, stage_updates);
             app.pipeline_groups.push(group);

--- a/src/ui/bar.rs
+++ b/src/ui/bar.rs
@@ -166,7 +166,7 @@ impl Widget for PipelinesTitle<'_> {
 
         if !self.expanded {
             for group in self.groups {
-                let color = if group.gone {
+                let color = if group.gone || group.pending_link {
                     Color::DarkGray
                 } else {
                     group.summary_status.color()
@@ -370,6 +370,7 @@ mod tests {
             stages: vec![],
             gone: false,
             summary_status,
+            pending_link: false,
         }
     }
 
@@ -795,6 +796,52 @@ mod tests {
             .filter(|c| c.symbol() == "\u{25CF}")
             .collect();
         assert_eq!(dots.len(), 2, "collapsed title should show dots");
+    }
+
+    #[test]
+    fn pipelines_title_pending_link_dims_dot() {
+        let mut g = make_pipe_group("pipe", BuildStatus::Succeeded);
+        g.pending_link = true;
+        let groups = vec![&g];
+        let widget = PipelinesTitle::new(&groups, false);
+        let area = Rect::new(0, 0, 40, 1);
+        let mut buf = Buffer::empty(area);
+        widget.render(area, &mut buf);
+
+        let dots: Vec<_> = buf
+            .content()
+            .iter()
+            .filter(|c| c.symbol() == "\u{25CF}")
+            .collect();
+        assert_eq!(dots.len(), 1);
+        assert_eq!(
+            dots[0].fg,
+            Color::DarkGray,
+            "pending_link should dim the dot to DarkGray"
+        );
+    }
+
+    #[test]
+    fn pipelines_title_pending_link_cleared_shows_status() {
+        let mut g = make_pipe_group("pipe", BuildStatus::Succeeded);
+        g.pending_link = false;
+        let groups = vec![&g];
+        let widget = PipelinesTitle::new(&groups, false);
+        let area = Rect::new(0, 0, 40, 1);
+        let mut buf = Buffer::empty(area);
+        widget.render(area, &mut buf);
+
+        let dots: Vec<_> = buf
+            .content()
+            .iter()
+            .filter(|c| c.symbol() == "\u{25CF}")
+            .collect();
+        assert_eq!(dots.len(), 1);
+        assert_eq!(
+            dots[0].fg,
+            Color::Green,
+            "without pending_link, dot should show status color"
+        );
     }
 
     #[test]

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -323,7 +323,7 @@ pub fn run_ui(
                         continue;
                     }
                     // Pipeline name header with status dot
-                    let dot_color = if group.gone {
+                    let dot_color = if group.gone || group.pending_link {
                         Color::DarkGray
                     } else {
                         group.summary_status.color()
@@ -337,7 +337,7 @@ pub fn run_ui(
                     idx += 1;
                     // Stage bars
                     for bar in &visible_stages {
-                        let bar_dim = dim || group.gone;
+                        let bar_dim = dim || group.gone || group.pending_link;
                         frame.render_widget(
                             BarWidget::new(bar, stage_name_width, bar_dim),
                             areas[idx],
@@ -533,12 +533,14 @@ mod tests {
                 stages: vec![],
                 gone: false,
                 summary_status: BuildStatus::Idle,
+                pending_link: false,
             },
             PipelineGroup {
                 name: "aaa-running".to_string(),
                 stages: vec![make_test_bar("Build", BuildStatus::Running)],
                 gone: false,
                 summary_status: BuildStatus::Running,
+                pending_link: false,
             },
         ];
         let sorted = sorted_pipeline_groups(&groups);
@@ -618,6 +620,7 @@ mod tests {
             ],
             gone: false,
             summary_status: BuildStatus::Idle,
+            pending_link: false,
         }];
         assert_eq!(all_pipeline_stages_name_width(&groups), 10); // 6 + 4
     }


### PR DESCRIPTION
## Summary

Add `pending_link` flag to `PipelineGroup` so linked CP bars stay fully gray until AWS reports them as Running.

## Problem

When a new GitHub Actions build starts, the poll scheduler transitions to `Active`, un-dimming ALL bars globally. This caused linked CodePipeline bars to become colored even though the pipeline hadn't started yet — it only starts after the GH Action succeeds and pushes artifacts to S3.

## Solution

- Add `pending_link: bool` to `PipelineGroup`
- `set_pending_links()` in `apply_links()`: sets flag when linked GH workflow is Running and CP is not yet Running
- UI treats `pending_link` like `gone` for dimming (collapsed dots, expanded header dots, stage bars)

## Tests

6 new tests:
- 4 linkage tests: pending_link set/cleared for linked/unlinked/succeeded scenarios
- 2 UI tests: collapsed dot dimming with pending_link