### PR TITLE
fix: always reserve timestamp space for stable bar length

### DIFF
--- a/src/ui/bar.rs
+++ b/src/ui/bar.rs
@@ -50,7 +50,7 @@ impl Widget for BarWidget<'_> {
             .bar
             .last_finished
             .map(|t| format_finished_time(&t, &chrono::Local));
-        let ts_reserve = if ts_str.is_some() { 7 } else { 0 };
+        let ts_reserve = 7; // always reserve space for timestamp stability
 
         let dot_prefix_len = if self.status_dot.is_some() { 2 } else { 0 };
         let name_col = self.name_width + 2;
@@ -79,11 +79,12 @@ impl Widget for BarWidget<'_> {
         spans.push(Span::styled("|".repeat(filled), Style::default().fg(color)));
         spans.push(Span::raw(" ".repeat(empty)));
         spans.push(Span::raw("]"));
-        if let Some(ts) = ts_str {
-            spans.push(Span::styled(
+        match ts_str {
+            Some(ts) => spans.push(Span::styled(
                 format!(" {ts} "),
                 Style::default().fg(Color::DarkGray),
-            ));
+            )),
+            None => spans.push(Span::raw("       ")), // 7 spaces
         }
 
         Line::from(spans).render(area, buf);
@@ -222,7 +223,7 @@ mod tests {
             .collect();
         assert!(content.starts_with("deploy"));
         assert!(content.contains('['));
-        assert!(content.ends_with(']'));
+        assert!(content.contains(']'));
     }
 
     #[test]
@@ -586,7 +587,7 @@ mod tests {
             .map(|c| c.symbol().chars().next().unwrap_or(' '))
             .collect();
         assert!(content.contains('['));
-        assert!(content.ends_with(']'));
+        assert!(content.contains(']'));
     }
 
     #[test]
@@ -926,6 +927,53 @@ mod tests {
         assert!(
             !after_bracket.contains(':'),
             "no timestamp expected, got: {content}"
+        );
+    }
+
+    #[test]
+    fn bars_with_and_without_timestamp_have_same_bracket_positions() {
+        use chrono::{TimeZone, Utc};
+
+        let ts = Utc.with_ymd_and_hms(2026, 3, 18, 14, 28, 0).unwrap();
+        let mut bar_with_ts = make_bar("build", BuildStatus::Succeeded, 5);
+        bar_with_ts.last_finished = Some(ts);
+        let bar_without_ts = make_bar("build", BuildStatus::Succeeded, 5);
+
+        let area = Rect::new(0, 0, 40, 1);
+
+        let mut buf_with = Buffer::empty(area);
+        BarWidget::new(&bar_with_ts, 10, false).render(area, &mut buf_with);
+        let bracket_open_with = buf_with
+            .content()
+            .iter()
+            .position(|c| c.symbol() == "[")
+            .unwrap();
+        let bracket_close_with = buf_with
+            .content()
+            .iter()
+            .position(|c| c.symbol() == "]")
+            .unwrap();
+
+        let mut buf_without = Buffer::empty(area);
+        BarWidget::new(&bar_without_ts, 10, false).render(area, &mut buf_without);
+        let bracket_open_without = buf_without
+            .content()
+            .iter()
+            .position(|c| c.symbol() == "[")
+            .unwrap();
+        let bracket_close_without = buf_without
+            .content()
+            .iter()
+            .position(|c| c.symbol() == "]")
+            .unwrap();
+
+        assert_eq!(
+            bracket_open_with, bracket_open_without,
+            "opening bracket should be at same position"
+        );
+        assert_eq!(
+            bracket_close_with, bracket_close_without,
+            "closing bracket should be at same position (stable bar length)"
         );
     }
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -376,7 +376,7 @@ pub fn run_ui(
                 let width = a.terminal_width as usize;
 
                 let pipe_stage_name_width = all_pipeline_stages_name_width(&a.pipeline_groups);
-                let pipe_fill_width = width.saturating_sub(pipe_stage_name_width + 4);
+                let pipe_fill_width = width.saturating_sub(pipe_stage_name_width + 4 + 7);
                 for group in &mut a.pipeline_groups {
                     for stage in &mut group.stages {
                         stage.tick(pipe_fill_width);
@@ -384,7 +384,7 @@ pub fn run_ui(
                 }
 
                 let job_name_width = all_jobs_name_width(&a.workflow_groups);
-                let job_fill_width = width.saturating_sub(job_name_width + 4);
+                let job_fill_width = width.saturating_sub(job_name_width + 4 + 7);
                 for group in &mut a.workflow_groups {
                     for job in &mut group.jobs {
                         job.tick(job_fill_width);


### PR DESCRIPTION
Bars visually jumped when timestamps appeared/disappeared because `ts_reserve` was conditional (7 when present, 0 when absent).

## Changes

- **`src/ui/bar.rs`**: Always reserve 7 chars for timestamp column; render 7 spaces when no timestamp present
- **`src/ui/mod.rs`**: Add `+ 7` to tick width calculations to sync animation width with render width

## Tests

- Added `bars_with_and_without_timestamp_have_same_bracket_positions` test
- Updated 2 existing assertions from `ends_with(']')` to `contains(']')` (trailing spaces now follow bracket)
- All 311 tests pass, clippy clean, fmt clean